### PR TITLE
added contextName option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules
 
 # Garbage files
 .DS_Store
+
+.idea

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,12 @@ declare namespace PluginError {
      * By default it uses the `stack` of the original error if you used one, otherwise it captures a new stack.
      */
     stack?: string;
+
+    /**
+     * Error context
+     * Default: 'plugin'
+     */
+    contextName?: string;
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ var extend = require('extend-shallow');
 var differ = require('arr-diff');
 var union = require('arr-union');
 
-var nonEnum = ['message', 'name', 'stack'];
+var nonEnum = ['message', 'name', 'stack', 'contextName'];
 var ignored = union(nonEnum, ['__safety', '_stack', 'plugin', 'showProperties', 'showStack']);
-var props = ['fileName', 'lineNumber', 'message', 'name', 'plugin', 'showProperties', 'showStack', 'stack'];
+var props = ['fileName', 'lineNumber', 'message', 'name', 'contextName', 'plugin', 'showProperties', 'showStack', 'stack'];
 
 function PluginError(plugin, message, options) {
   if (!(this instanceof PluginError)) {
@@ -37,6 +37,9 @@ function PluginError(plugin, message, options) {
   // Defaults
   if (!this.name) {
     this.name = 'Error';
+  }
+  if (!this.contextName) {
+    this.contextName = 'plugin';
   }
   if (!this.stack) {
 
@@ -139,7 +142,9 @@ PluginError.prototype.toString = function() {
 // Format the output message
 function message(msg, thisArg) {
   var sig = colors.red(thisArg.name);
-  sig += ' in plugin ';
+  sig += ' in';
+  sig += thisArg.contextName;
+  sig += ' ';
   sig += '"' + colors.cyan(thisArg.plugin) + '"';
   sig += '\n';
   sig += msg;

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ PluginError.prototype.toString = function() {
 // Format the output message
 function message(msg, thisArg) {
   var sig = colors.red(thisArg.name);
-  sig += ' in';
+  sig += ' in ';
   sig += thisArg.contextName;
   sig += ' ';
   sig += '"' + colors.cyan(thisArg.plugin) + '"';

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,20 @@ describe('PluginError()', function() {
     done();
   });
 
+  it('should default the context name to plugin', function(done) {
+    var realErr = { message: 'something broke' };
+    var err = new PluginError('test', realErr);
+    expect(err.toString()).toContain(' in plugin ');
+    done();
+  });
+
+  it('should say in task when we set the context name to task', function(done) {
+    var realErr = { message: 'something broke', contextName: 'task' };
+    var err = new PluginError('test', realErr);
+    expect(err.toString()).toContain(' in task ');
+    done();
+  });
+
   it('should print the plugin name in toString', function(done) {
     var err = new PluginError('test', 'something broke');
     expect(err.toString()).toContain('test');


### PR DESCRIPTION
I wanted to extend the use for not only plugins but any type of context. Since I'm using this in Gulp I wanted to have the error message be: `Error in task run-tests` rather than `Error in plugin run-tests`.

I hope I added the options to the right places. 

✔️ The tests ran 100%. 
✔️ Default value is `plugin` so it has backwards compatibility.