### PR TITLE
Adjust test matrix for Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: node_js
 node_js:
+  - '13'
+  - '12'
+  - '10'
   - '8'
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'
 after_script:
   - npm run coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,12 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
+    - nodejs_version: "12"
+    - nodejs_version: "13"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Remove Node.js 0.10 and 0.12, which are failing anyway
Add testing for newer versions of Node.js