### PR TITLE
fix!: Avoid modifying arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,13 +154,12 @@ function setDefaults(plugin, message, opts) {
   if (typeof plugin === 'object') {
     return defaults(plugin);
   }
-  opts = opts || {};
   if (message instanceof Error) {
-    opts.error = message;
+    opts = extend({}, opts, { error: message });
   } else if (typeof message === 'object') {
-    opts = message;
+    opts = extend({}, message);
   } else {
-    opts.message = message;
+    opts = extend({}, opts, { message: message });
   }
   opts.plugin = plugin;
   return defaults(opts);

--- a/index.js
+++ b/index.js
@@ -155,11 +155,11 @@ function setDefaults(plugin, message, opts) {
     return defaults(plugin);
   }
   if (message instanceof Error) {
-    opts = extend({}, opts, { error: message });
+    opts = Object.assign({}, opts, { error: message });
   } else if (typeof message === 'object') {
-    opts = extend({}, message);
+    opts = Object.assign({}, message);
   } else {
-    opts = extend({}, opts, { message: message });
+    opts = Object.assign({}, opts, { message: message });
   }
   opts.plugin = plugin;
   return defaults(opts);

--- a/test/index.js
+++ b/test/index.js
@@ -213,4 +213,18 @@ describe('PluginError()', function() {
     expect(err.toString().indexOf('Details:')).toEqual(-1);
     done();
   });
+
+  it('should not modify error argument', function(done) {
+    var realErr = { message: 'something broke' };
+    new PluginError('test', realErr);
+    expect(realErr).toEqual({ message: 'something broke' });
+    done();
+  });
+
+  it('should not modify options argument', function(done) {
+    var opts = { showStack: true };
+    new PluginError('test', 'message', opts);
+    expect(opts).toEqual({ showStack: true });
+    done();
+  });
 });


### PR DESCRIPTION
Currently, plugin-error modifies the arguments provided to it (errors or option objects) by adding a `plugin` property and sometimes a `error` or `message` property to them. This is inconvenient because sometimes you would like to reuse an argument later without having it modified after the first usage of plugin-error.

This PR changes the current behavior by ensuring that the argument interpreted as an options object is shallow-cloned before any additional properties are set.