### PR TITLE
fix: Exclude `domainEmitter` from output

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var ignored = new Set(
     'showProperties',
     'showStack',
     'domain',
+    'domainEmitter',
     'domainThrown',
   ])
 );

--- a/test/index.js
+++ b/test/index.js
@@ -252,6 +252,19 @@ describe('PluginError()', function () {
     done();
   });
 
+  it('should not show additional properties added by a domain', function (done) {
+    var Duplex = require('stream').Duplex;
+    var stream = new Duplex({ objectMode: true });
+    var domain = require('domain').create();
+    domain.add(stream);
+    domain.on('error', function (err) {
+      expect(err).toBeInstanceOf(PluginError);
+      expect(err.toString()).not.toContain('domain');
+      done();
+    });
+    stream.emit('error', new PluginError('plugin', 'message'));
+  });
+
   it('should not modify error argument', function (done) {
     var realErr = { message: 'something broke' };
     new PluginError('test', realErr);


### PR DESCRIPTION
This excludes the property `domainEmitter` from the `toString` output.

References: #14, #25

Like `domain` and `domainThrown`, this property is only attached to errors that occur inside a [domain](https://nodejs.org/api/domain.html), with `domainEmitter` holding a reference to the stream that emitted the error.

